### PR TITLE
Add event handler for WM_Close

### DIFF
--- a/engine/src/platform/platform_win32.c
+++ b/engine/src/platform/platform_win32.c
@@ -5,6 +5,7 @@
 
 #include "core/logger.h"
 #include "core/input.h"
+#include "core/event.h"
 
 #include "containers/darray.h"
 
@@ -222,7 +223,9 @@ LRESULT CALLBACK win32_process_message(HWND hwnd, u32 msg, WPARAM w_param, LPARA
             return 1;
         case WM_CLOSE:
             // TODO: Fire an event for the application to quit.
-            return 0;
+            event_context data = {};
+            event_fire(EVENT_CODE_APPLICATION_QUIT, 0, data);
+            return TRUE;
         case WM_DESTROY:
             PostQuitMessage(0);
             return 0;


### PR DESCRIPTION
#include "core/event.h", so that WM_CLOSE messaged (produced by clicking the close button) can fire EVENT_CODE_APPLICATION_QUIT, shutting the application down as expected.