### PR TITLE
Add clang / GCC support for KINLINE and KNOINLINE

### DIFF
--- a/engine/src/defines.h
+++ b/engine/src/defines.h
@@ -102,7 +102,10 @@ STATIC_ASSERT(sizeof(f64) == 8, "Expected f64 to be 8 bytes.");
                                                                       : value;
                                                                       
 // Inlining
-#ifdef _MSC_VER
+#if defined(__clang__) || defined(__gcc__)
+#define KINLINE __attribute__((always_inline)) inline
+#define KNOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
 #define KINLINE __forceinline
 #define KNOINLINE __declspec(noinline)
 #else


### PR DESCRIPTION
This PR just adds the attributes that gcc and clang expect for preventing / forcing inline. This should make it so KINLINE and KNOINLINE work correctly on Linux