### PR TITLE
Fix SIMD compile-time errors

### DIFF
--- a/engine/src/math/kmath.h
+++ b/engine/src/math/kmath.h
@@ -570,7 +570,7 @@ KINLINE vec3 vec4_to_vec3(vec4 vector) {
 KINLINE vec4 vec4_from_vec3(vec3 vector, f32 w) {
 #if defined(KUSE_SIMD)
     vec4 out_vector;
-    out_vector.data = _mm_setr_ps(x, y, z, w);
+    out_vector.data = _mm_setr_ps(vector.x, vector.y, vector.z, vector.w);
     return out_vector;
 #else
     return (vec4){vector.x, vector.y, vector.z, w};

--- a/engine/src/math/math_types.h
+++ b/engine/src/math/math_types.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "defines.h"
+#include <stdalign.h>
+#include <immintrin.h>
 
 typedef union vec2_u {
     // An array of x, y
@@ -37,9 +39,13 @@ typedef union vec3_u {
 } vec3;
 
 typedef union vec4_u {
+#if defined(KUSE_SIMD)
+    alignas(16) __m128 data;
+#endif
 
     // An array of x, y, z, w
-    f32 elements[4];
+    alignas(16) f32 elements[4];
+
     union {
         struct {
             union {
@@ -65,5 +71,8 @@ typedef union vec4_u {
 typedef vec4 quat;
 
 typedef union mat4_u {
-    f32 data[16];
+    alignas(16) f32 data[16];
+#if defined(KUSE_SIMD)
+    alignas(16) vec4 rows[4];
+#endif
 } mat4;


### PR DESCRIPTION
I wasn't sure if you wanted these changes, since we're not using SIMD, yet. These are relatively simple changes to make Kohi able to compile with KUSE_SIMD

## kmath.h
- In `vec4_from_vec3`, the `x`, `y`, `z`, `w` variables are undefined. These values should come from the local `vector` variable

## math_types.h
- `alignas` is a keyword of C++, whereas the equivalent keyword in C11 is `_Alignas`. The `<stdalign.h>` header file just makes a simple macro to reconcile these differences
- Also, we need the `<immintrin.h>` header to define the `__m128` type and `__mm_setr_ps` function