### PR TITLE
Fix uninitialized memory usage

### DIFF
--- a/engine/src/platform/platform_linux.c
+++ b/engine/src/platform/platform_linux.c
@@ -192,12 +192,7 @@ b8 platform_pump_messages(platform_state* plat_state) {
     b8 quit_flagged = FALSE;
 
     // Poll for events until null is returned.
-    while (event != 0) {
-        event = xcb_poll_for_event(state->connection);
-        if (event == 0) {
-            break;
-        }
-
+    while (event = xcb_poll_for_event(state->connection)) {
         // Input events
         switch (event->response_type & ~0x80) {
             case XCB_KEY_PRESS:


### PR DESCRIPTION
The Linux event loop was using uninitialized memory on its first iteration.