### PR TITLE
Bugfix/59

### DIFF
--- a/engine/src/containers/freelist.c
+++ b/engine/src/containers/freelist.c
@@ -196,6 +196,13 @@ b8 freelist_resize(freelist* list, u64* memory_requirement, void* new_memory, u6
 
     // Enough space to hold state, plus array for all nodes.
     u64 max_entries = (new_size / sizeof(void*));  // NOTE: This might have a remainder, but that's ok.
+    
+    // Catch an edge case of having a really small amount of memory to manage, and only having a
+    // super small number of entries. Always make sure we have at least a decent amount, like 20 or so.
+    if (max_entries < 20) {
+        max_entries = 20;
+    }
+
     *memory_requirement = sizeof(internal_state) + (sizeof(freelist_node) * max_entries);
     if (!new_memory) {
         return true;

--- a/engine/src/containers/freelist.c
+++ b/engine/src/containers/freelist.c
@@ -21,7 +21,14 @@ void return_node(freelist* list, freelist_node* node);
 
 void freelist_create(u64 total_size, u64* memory_requirement, void* memory, freelist* out_list) {
     // Enough space to hold state, plus array for all nodes.
-    u64 max_entries = (total_size / (sizeof(void*) * sizeof(freelist_node)));  //NOTE: This might have a remainder, but that's ok.
+    u64 max_entries = (total_size / (sizeof(void*) * sizeof(freelist_node)));  // NOTE: This might have a remainder, but that's ok.
+
+    // Catch an edge case of having a really small amount of memory to manage, and only having a
+    // super small number of entries. Always make sure we have at least a decent amount, like 20 or so.
+    if (max_entries < 20) {
+        max_entries = 20;
+    }
+
     *memory_requirement = sizeof(internal_state) + (sizeof(freelist_node) * max_entries);
     if (!memory) {
         return;
@@ -188,7 +195,7 @@ b8 freelist_resize(freelist* list, u64* memory_requirement, void* new_memory, u6
     }
 
     // Enough space to hold state, plus array for all nodes.
-    u64 max_entries = (new_size / sizeof(void*));  //NOTE: This might have a remainder, but that's ok.
+    u64 max_entries = (new_size / sizeof(void*));  // NOTE: This might have a remainder, but that's ok.
     *memory_requirement = sizeof(internal_state) + (sizeof(freelist_node) * max_entries);
     if (!new_memory) {
         return true;


### PR DESCRIPTION
Fixed an issue where a small allocation might result in a very small amount of available nodes. In this case, 20 nodes are created to ensure there are enough.

Ideally, a freelist shouldn't be used with tons of really tiny allocations, so this should be ok.

Can always revisit this in the future if/when needed.