### PR TITLE
[#75] Increase Windows sleep accuracy beyond 64 ticks per second

### DIFF
--- a/Makefile.library.mak
+++ b/Makefile.library.mak
@@ -13,7 +13,7 @@ ifeq ($(OS),Windows_NT)
 	EXTENSION := .dll
 	COMPILER_FLAGS := -Wall -Wextra -Werror -Wno-error=deprecated-declarations -Wno-error=unused-function -Wvla -Wgnu-folding-constant -Wno-missing-braces -fdeclspec -Wstrict-prototypes -Wno-unused-parameter -Wno-missing-field-initializers
 	INCLUDE_FLAGS := -I$(ASSEMBLY)\src $(ADDL_INC_FLAGS)
-	LINKER_FLAGS := -shared -L$(OBJ_DIR)\$(ASSEMBLY) -L.\$(BUILD_DIR) $(ADDL_LINK_FLAGS)
+	LINKER_FLAGS := -shared -lwinmm -L$(OBJ_DIR)\$(ASSEMBLY) -L.\$(BUILD_DIR) $(ADDL_LINK_FLAGS)
 	DEFINES += -D_CRT_SECURE_NO_WARNINGS -DUNICODE
 
 # Make does not offer a recursive wildcard function, and Windows needs one, so here it is:


### PR DESCRIPTION
Addresses #75 

Increases the accuracy of the underlying timer device while sleeping in order to allow for more accurate thread sleeps on Windows. 

According to [](https://stackoverflow.com/a/19427182):

"Sleep() is accurate to the operating system's clock interrupt rate. Which by default on Windows ticks 64 times per second. Or once every 15.625 msec, as you found out. You can increase that rate, call timeBeginPeriod(10). Use timeEndPeriod(10) when you're done. You are still subject to normal thread scheduling latencies so you still don't have a guarantee that your thread will resume running after 10 msec. And won't when the machine is heavily loaded. Using SetThreadPriority() to boost the priority, increasing the odds that it will."

However instead of using a hardcoded value, this fix queries the minimum period of the underlying hardware timer via `timeGetDevCaps()` in the `clock_setup()` function.

Note that the sleep time does still seem to be quite unreliable, and it seems its because getting reliable timings on Windows can be notoriously difficult. Apparently using `Sleep()` is not really recommended for these kinds of applications. Would have to look further into that. I've seen some ideas floating around about combining sleeping with spinlocking as a potential way to increase accuracy (at the cost of more CPU usage).