### PR TITLE
[#162] Use stderr instead of stdout to print errors on linux

### DIFF
--- a/engine/src/platform/platform_linux.c
+++ b/engine/src/platform/platform_linux.c
@@ -321,7 +321,7 @@ void platform_console_write(const char* message, u8 colour) {
 void platform_console_write_error(const char* message, u8 colour) {
     // FATAL,ERROR,WARN,INFO,DEBUG,TRACE
     const char* colour_strings[] = {"0;41", "1;31", "1;33", "1;32", "1;34", "1;30"};
-    printf("\033[%sm%s\033[0m", colour_strings[colour], message);
+    fprintf(stderr, "\033[%sm%s\033[0m", colour_strings[colour], message);
 }
 
 f64 platform_get_absolute_time(void) {


### PR DESCRIPTION
fixes: #162