### PR TITLE
Kohi game engine linux build issues

### DIFF
--- a/Makefile.executable.mak
+++ b/Makefile.executable.mak
@@ -48,7 +48,7 @@ else
 		# These are linux-specific, as the default behaviour is the opposite of this, allowing code to compile 
 		# here that would not on other platforms from not being exported (i.e. Windows)
 		# Discovered the solution here for this: https://github.com/ziglang/zig/issues/8180
-		LINKER_FLAGS :=-Wl,--no-undefined,--no-allow-shlib-undefined -L./$(BUILD_DIR) $(ADDL_LINK_FLAGS) -Wl,-rpath,. -Xlinker /INCREMENTAL
+		LINKER_FLAGS :=-Wl,--no-undefined,--no-allow-shlib-undefined -L./$(BUILD_DIR) $(ADDL_LINK_FLAGS) -Wl,-rpath,.
 		# .c files
 		SRC_FILES := $(shell find $(ASSEMBLY) -name *.c)
 		# directories with .h files

--- a/Makefile.library.mak
+++ b/Makefile.library.mak
@@ -49,7 +49,7 @@ else
 		# These are linux-specific, as the default behaviour is the opposite of this, allowing code to compile 
 		# here that would not on other platforms from not being exported (i.e. Windows)
 		# Discovered the solution here for this: https://github.com/ziglang/zig/issues/8180
-		LINKER_FLAGS :=-Wl,--no-undefined,--no-allow-shlib-undefined -shared -lvulkan -lxcb -lX11 -lXrandr -lX11-xcb -lxkbcommon -lm -L$(VULKAN_SDK)/lib -L/usr/X11R6/lib -L./$(BUILD_DIR) $(ADDL_LINK_FLAGS) 		# .c files
+		LINKER_FLAGS :=-Wl,--no-undefined,--no-allow-shlib-undefined -shared -ldl -lvulkan -lxcb -lX11 -lXrandr -lX11-xcb -lxkbcommon -lm -L$(VULKAN_SDK)/lib -L/usr/X11R6/lib -L./$(BUILD_DIR) $(ADDL_LINK_FLAGS) 		# .c files
 		SRC_FILES := $(shell find $(ASSEMBLY) -name *.c)
 		# directories with .h files
 		DIRECTORIES := $(shell find $(ASSEMBLY) -type d)

--- a/Makefile.library.mak
+++ b/Makefile.library.mak
@@ -49,7 +49,7 @@ else
 		# These are linux-specific, as the default behaviour is the opposite of this, allowing code to compile 
 		# here that would not on other platforms from not being exported (i.e. Windows)
 		# Discovered the solution here for this: https://github.com/ziglang/zig/issues/8180
-		LINKER_FLAGS :=-Wl,--no-undefined,--no-allow-shlib-undefined -shared -ldl -lvulkan -lxcb -lX11 -lXrandr -lX11-xcb -lxkbcommon -lm -L$(VULKAN_SDK)/lib -L/usr/X11R6/lib -L./$(BUILD_DIR) $(ADDL_LINK_FLAGS) 		# .c files
+		LINKER_FLAGS :=-Wl,--no-undefined,--no-allow-shlib-undefined -shared -ldl -pthread -lvulkan -lxcb -lX11 -lXrandr -lX11-xcb -lxkbcommon -lm -L$(VULKAN_SDK)/lib -L/usr/X11R6/lib -L./$(BUILD_DIR) $(ADDL_LINK_FLAGS) 		# .c files
 		SRC_FILES := $(shell find $(ASSEMBLY) -name *.c)
 		# directories with .h files
 		DIRECTORIES := $(shell find $(ASSEMBLY) -type d)

--- a/engine/src/systems/font_system.c
+++ b/engine/src/systems/font_system.c
@@ -12,6 +12,8 @@
 
 // For system fonts.
 #define STB_TRUETYPE_IMPLEMENTATION
+// To prevent warning errors on unused variables.
+#define UNUSED(x) (void) x
 #include "vendor/stb_truetype.h"
 
 typedef struct bitmap_font_internal_data {
@@ -417,6 +419,7 @@ vec2 font_system_measure_string(font_data* font, const char* text) {
 
     // Take the length in chars and get the correct codepoint from it.
     for (u32 c = 0, uc = 0; c < char_length; ++c) {
+        UNUSED(uc);
         i32 codepoint = text[c];
 
         // Continue to next line for newline.


### PR DESCRIPTION
While attempting to build `Kohi Game Engine` on my Linux machine, I encountered several errors and issues during the compilation process. Here are the changes I made to compile the Kohi Game Engine:

    **Removed the [-Xlinker /INCREMENTAL] linker flag.
    **Defined the UNUSED macro.
    **Added the -ldl flag to the linker commands to prevent the linker error.
    **Added the -lpthread flag to the linker commands to prevent the linker error.

These adjustments were made to address the compilation errors and ensure the successful compilation of the `Kohi Game Engine` on my Linux machine.

Thanks, @vheidari