### PR TITLE
Remove discrete GPU requirement

### DIFF
--- a/kohi.plugin.renderer.vulkan/src/vulkan_device.c
+++ b/kohi.plugin.renderer.vulkan/src/vulkan_device.c
@@ -421,11 +421,8 @@ static b8 select_physical_device(vulkan_context* context) {
     // NOTE: Enable this if compute will be required.
     // requirements.compute = true;
     requirements.sampler_anisotropy = true;
-#if KPLATFORM_APPLE
+    //TODO: Make this configurable
     requirements.discrete_gpu = false;
-#else
-    requirements.discrete_gpu = true;
-#endif
     requirements.device_extension_names = darray_create(const char*);
     darray_push(requirements.device_extension_names, &VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 


### PR DESCRIPTION
At the moment-- Kohi will only allow an integrated graphics card for macOS devices. This pull request removes that requirement for all systems. This allows the engine to work on my laptop.

If you feel this change is not appropriate, please let me know!