### PR TITLE
Automatically locate Make for Windows (build script)

### DIFF
--- a/build-all.bat
+++ b/build-all.bat
@@ -39,7 +39,7 @@ if "%PLATFORM%" == "windows" (
 
 REM Attempt to locate make
 set make=make
-%make% -v > nul
+%make% -v >nul 2>&1
 
 REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
 if "%ERRORLEVEL%"=="9009" (
@@ -54,7 +54,7 @@ echo Make not found in path. Checking default install location.
 	
 REM Attempt to locate make in default install location
 set make="%programfiles(x86)%\GnuWin32\bin\make.exe"
-%make% -v > nul
+%make% -v >nul 2>&1
 
 REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
 if "%ERRORLEVEL%"=="9009" (

--- a/build-all.bat
+++ b/build-all.bat
@@ -39,7 +39,7 @@ if "%PLATFORM%" == "windows" (
 
 REM Attempt to locate make
 set make=make
-%make% -v
+%make% -v > nul
 
 REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
 if "%ERRORLEVEL%"=="9009" (
@@ -54,7 +54,7 @@ echo Make not found in path. Checking default install location.
 	
 REM Attempt to locate make in default install location
 set make="%programfiles(x86)%\GnuWin32\bin\make.exe"
-%make% -v
+%make% -v > nul
 
 REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
 if "%ERRORLEVEL%"=="9009" (

--- a/build-all.bat
+++ b/build-all.bat
@@ -45,8 +45,8 @@ REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
 if "%ERRORLEVEL%"=="9009" (
     goto makenotfound
 ) else (
-	echo Make found in path.
-	goto makefound
+    echo Make found in path.
+    goto makefound
 )
 
 :makenotfound

--- a/build-all.bat
+++ b/build-all.bat
@@ -37,6 +37,34 @@ if "%PLATFORM%" == "windows" (
     )
 )
 
+REM Attempt to locate make
+set make=make
+%make% -v
+
+REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
+if "%ERRORLEVEL%"=="9009" (
+    goto makenotfound
+) else (
+	echo Make found in path.
+	goto makefound
+)
+
+:makenotfound
+echo Make not found in path. Checking default install location.
+	
+REM Attempt to locate make in default install location
+set make="%programfiles(x86)%\GnuWin32\bin\make.exe"
+%make% -v
+
+REM Check against errorlevel 9009 (MSG_DIR_BAD_COMMAND_OR_FILE)
+if "%ERRORLEVEL%"=="9009" (
+    echo Make not found in default install location. Aborting && exit
+) else (
+    echo Make found in default install location.
+)
+
+:makefound
+
 REM del bin\*.pdb
 
 SET INC_CORE_RT=-Ikohi.core\src -Ikohi.runtime\src
@@ -45,31 +73,31 @@ SET LNK_CORE_RT=-lkohi.core -lkohi.runtime
 ECHO "%ACTION_STR% everything on %PLATFORM% (%TARGET%)..."
 
 REM Version Generator - Build this first so it can be used later in the build process.
-make -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.tools.versiongen
+%make% -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.tools.versiongen
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Engine core lib
-make -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.core DO_VERSION=%DO_VERSION% ADDL_LINK_FLAGS="-lgdi32 %ENGINE_LINK%"
+%make% -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.core DO_VERSION=%DO_VERSION% ADDL_LINK_FLAGS="-lgdi32 %ENGINE_LINK%"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Engine runtime lib
-make -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.runtime DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="-lkohi.core %ENGINE_LINK%"
+%make% -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.runtime DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="-lkohi.core %ENGINE_LINK%"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Vulkan Renderer plugin lib
-make -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.plugin.renderer.vulkan DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT% -I%VULKAN_SDK%\include" ADDL_LINK_FLAGS="%LNK_CORE_RT% -lvulkan-1 -lshaderc_shared -L%VULKAN_SDK%\Lib"
+%make% -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.plugin.renderer.vulkan DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT% -I%VULKAN_SDK%\include" ADDL_LINK_FLAGS="%LNK_CORE_RT% -lvulkan-1 -lshaderc_shared -L%VULKAN_SDK%\Lib"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM OpenAL plugin lib
-make -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.plugin.audio.openal DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT% -I'%programfiles(x86)%\OpenAL 1.1 SDK\include'" ADDL_LINK_FLAGS="%LNK_CORE_RT% -lopenal32 -L'%programfiles(x86)%\OpenAL 1.1 SDK\libs\win64'"
+%make% -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.plugin.audio.openal DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT% -I'%programfiles(x86)%\OpenAL 1.1 SDK\include'" ADDL_LINK_FLAGS="%LNK_CORE_RT% -lopenal32 -L'%programfiles(x86)%\OpenAL 1.1 SDK\libs\win64'"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Standard UI lib
-make -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.plugin.ui.standard DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
+%make% -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.plugin.ui.standard DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Testbed lib
-make -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=testbed.klib DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT% -Ikohi.plugin.ui.standard\src -Ikohi.plugin.audio.openal\src" ADDL_LINK_FLAGS="%LNK_CORE_RT% -lkohi.plugin.ui.standard -lkohi.plugin.audio.openal"
+%make% -j -f "Makefile.library.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=testbed.klib DO_VERSION=%DO_VERSION% ADDL_INC_FLAGS="%INC_CORE_RT% -Ikohi.plugin.ui.standard\src -Ikohi.plugin.audio.openal\src" ADDL_LINK_FLAGS="%LNK_CORE_RT% -lkohi.plugin.ui.standard -lkohi.plugin.audio.openal"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 @REM ---------------------------------------------------
@@ -77,15 +105,15 @@ IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 @REM ---------------------------------------------------
 
 REM Testbed
-make -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=testbed.kapp ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
+%make% -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=testbed.kapp ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Tests
-make -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.core.tests ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
+%make% -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.core.tests ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 REM Tools
-make -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.tools ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
+%make% -j -f "Makefile.executable.mak" %ACTION% TARGET=%TARGET% ASSEMBLY=kohi.tools ADDL_INC_FLAGS="%INC_CORE_RT%" ADDL_LINK_FLAGS="%LNK_CORE_RT%"
 IF %ERRORLEVEL% NEQ 0 (echo Error:%ERRORLEVEL% && exit)
 
 ECHO All assemblies %ACTION_STR_PAST% successfully on %PLATFORM% (%TARGET%).


### PR DESCRIPTION
Intended to simplify the updated build documentation for Windows (PR https://github.com/travisvroman/kohi/pull/241), I've added a feature to the Windows build script.

This feature automatically locates `make.exe` from either:
 1. The Path Environment Variable
 2. The default install location for Make for Windows (`C:\Program Files (x86)\GnuWin32\bin`)

This works by running `make -v` (a version check command for make) then checking whether the `%errorlevel%` variable is equal to `9009` (which is the error code for `MSG_DIR_BAD_COMMAND_OR_FILE`, signifying that make is not found from the system path)

If make is not found from simply running `make -v`, then the script attempts to run `C:\Program Files (x86)\GnuWin32\bin\make.exe -v`, and checks for the same error `9009`. If make is still not found, the build script aborts.

If this is accepted, the updated build documentation in PR https://github.com/travisvroman/kohi/pull/241 could be simplified to remove the requirement to [manually add Make to the system path](https://github.com/travisvroman/kohi/blob/513f135b5f705fb3796fcdbba4d95a41a97fa857/readme.md?plain=1#L72).

I understand that this may not be the most elegant solution-- But I feel it would be better to add a small amount of complexity to the build script for the sake of greatly simplifying the build documentation.
