### PR TITLE
Uninvert skybox Z texcoord.

### DIFF
--- a/Makefile.library.mak
+++ b/Makefile.library.mak
@@ -49,7 +49,7 @@ else
 		EXTENSION := .so
 		# NOTE: -fvisibility=hidden hides all symbols by default, and only those that explicitly say
 		# otherwise are exported (i.e. via KAPI).
-		COMPILER_FLAGS :=-fvisibility=hidden -fpic -Wall -Wno-error=deprecated-declarations -Wno-error=unused-function -Werror -Wvla -Wno-missing-braces -fdeclspec 
+		COMPILER_FLAGS :=-fvisibility=hidden -fpic -Wall -Wno-error=deprecated-declarations -Wno-error=unused-function -Wno-error=tautological-compare -Werror -Wvla -Wno-missing-braces -fdeclspec 
 		INCLUDE_FLAGS := -I./$(ASSEMBLY)/src $(ADDL_INC_FLAGS)
 		# NOTE: --no-undefined and --no-allow-shlib-undefined ensure that symbols linking against are resolved.
 		# These are linux-specific, as the default behaviour is the opposite of this, allowing code to compile 

--- a/kohi.runtime/assets/shaders/Shader.Skybox_vert.glsl
+++ b/kohi.runtime/assets/shaders/Shader.Skybox_vert.glsl
@@ -37,7 +37,7 @@ layout(location = 0) out dto {
 } out_dto;
 
 void main() {
-	out_dto.tex_coord = in_position;
+	out_dto.tex_coord = in_position * vec3(1, 1, -1);
 	const uint view_index = skybox_draw_ubo.options[SKYBOX_OPTION_IDX_VIEW_INDEX];
 	gl_Position = skybox_frame_ubo.projection * skybox_frame_ubo.views[view_index] * vec4(in_position, 1.0);
 } 


### PR DESCRIPTION
Fixes skybox texcoord being inverted by Z coordinate. Tested on Minecraft's panorama (before and after):
![2025-06-15-203820_hyprshot](https://github.com/user-attachments/assets/5c06122d-7df2-4473-9a5f-598497025efb)
![2025-06-15-203936_hyprshot](https://github.com/user-attachments/assets/92627c03-7f54-478d-a7e8-3e5f6a539b73)

Also fixed build error caused by compiler warning in `stb_vorbis.c` (only for Linux, I didn't test it on Windows).