### PR TITLE
Replace old hashtables with new flat hashtables.

### DIFF
--- a/kohi.core.tests/Makefile
+++ b/kohi.core.tests/Makefile
@@ -118,7 +118,7 @@ link-win32: OUTPUT_NAME = bin\$(ASSEMBLY_NAME).exe
 # 		here that would not on other platforms from not being exported (i.e. Windows)
 # 		Discovered the solution here for this: https://github.com/ziglang/zig/issues/8180
 link-linux: CFLAGS += -Wno-cast-function-type-mismatch -fPIC
-link-linux: LDFLAGS += -lm
+link-linux: LDFLAGS += -lm -Wl,-rpath='$$ORIGIN'
 link-linux: OUTPUT_NAME = bin/$(ASSEMBLY_NAME)
 
 link-macos: LDFLAGS += 

--- a/kohi.core.tests/src/containers/hashtable_tests.c
+++ b/kohi.core.tests/src/containers/hashtable_tests.c
@@ -7,325 +7,321 @@
 
 u8 hashtable_should_create_and_destroy(void) {
 	hashtable table;
-	u64 element_size = sizeof(u64);
-	u64 element_count = 3;
-	u64 memory[3];
-
-	hashtable_create(element_size, element_count, memory, false, &table);
+	hashtable_create(sizeof(u64), 4, false, &table);
 
 	expect_should_not_be(0, table.memory);
 	expect_should_be(sizeof(u64), table.element_size);
-	expect_should_be(3, table.element_count);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	hashtable_destroy(&table);
 
 	expect_should_be(0, table.memory);
 	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	return true;
 }
 
 u8 hashtable_should_set_and_get_successfully(void) {
 	hashtable table;
-	u64 element_size = sizeof(u64);
-	u64 element_count = 3;
-	u64 memory[3];
-
-	hashtable_create(element_size, element_count, memory, false, &table);
+	hashtable_create(sizeof(u64), 4, false, &table);
 
 	expect_should_not_be(0, table.memory);
 	expect_should_be(sizeof(u64), table.element_size);
-	expect_should_be(3, table.element_count);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
-	u64 testval1 = 23;
-	hashtable_set(&table, "test1", &testval1);
-	u64 get_testval_1 = 0;
-	hashtable_get(&table, "test1", &get_testval_1);
-	expect_should_be(testval1, get_testval_1);
+	const char* keys[4] = {
+		"one",
+		"two",
+		"three",
+		"four",
+	};
+	u64 values[4] = {
+		1,
+		2,
+		3,
+		4,
+	};
+
+	for (i32 i = 0; i < 4; i++) {
+		hashtable_set(&table, keys[i], &values[i]);
+	}
+
+	expect_should_be(4, table.filled);
+
+	for (i32 i = 0; i < 4; i++) {
+		u64 value;
+		b8 get_result = hashtable_get(&table, keys[i], &value);
+		expect_to_be_true(get_result);
+
+		expect_should_be(value, values[i]);
+	}
 
 	hashtable_destroy(&table);
 
 	expect_should_be(0, table.memory);
 	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	return true;
 }
 
-typedef struct ht_test_struct {
-	b8 b_value;
-	f32 f_value;
-	u64 u_value;
-} ht_test_struct;
+u8 hashtable_should_grow_successfully(void) {
+	hashtable table;
+	hashtable_create(sizeof(u64), 4, false, &table);
+
+	expect_should_not_be(0, table.memory);
+	expect_should_be(sizeof(u64), table.element_size);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
+
+	const char* keys[10] = {
+		"one",
+		"two",
+		"three",
+		"four",
+		"five",
+		"six",
+		"seven",
+		"eight",
+		"nine",
+		"ten",
+	};
+	u64 values[10] = {
+		1,
+		2,
+		3,
+		4,
+		5,
+		6,
+		7,
+		8,
+		9,
+		10,
+	};
+
+	for (i32 i = 0; i < 10; i++) {
+		hashtable_set(&table, keys[i], &values[i]);
+	}
+
+	expect_should_be(10, table.filled);
+	expect_should_be(16, table.capacity);
+
+	for (i32 i = 0; i < 10; i++) {
+		u64 value;
+		b8 get_result = hashtable_get(&table, keys[i], &value);
+		expect_to_be_true(get_result);
+
+		expect_should_be(value, values[i]);
+	}
+
+	hashtable_destroy(&table);
+
+	expect_should_be(0, table.memory);
+	expect_should_be(0, table.element_size);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
+
+	return true;
+}
 
 u8 hashtable_should_set_and_get_ptr_successfully(void) {
 	hashtable table;
-	u64 element_size = sizeof(ht_test_struct*);
-	u64 element_count = 3;
-	ht_test_struct* memory[3];
-
-	hashtable_create(element_size, element_count, memory, true, &table);
+	hashtable_create(sizeof(u64*), 4, true, &table);
 
 	expect_should_not_be(0, table.memory);
-	expect_should_be(sizeof(ht_test_struct*), table.element_size);
-	expect_should_be(3, table.element_count);
+	expect_should_be(sizeof(u64*), table.element_size);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_true(table.is_pointer_type);
 
-	ht_test_struct t;
-	ht_test_struct* testval1 = &t;
-	testval1->b_value = true;
-	testval1->u_value = 63;
-	testval1->f_value = 3.1415f;
-	hashtable_set_ptr(&table, "test1", (void**)&testval1);
+	const char* keys[4] = {
+		"one",
+		"two",
+		"three",
+		"four",
+	};
+	u64 values[4] = {
+		1,
+		2,
+		3,
+		4,
+	};
 
-	ht_test_struct* get_testval_1 = 0;
-	hashtable_get_ptr(&table, "test1", (void**)&get_testval_1);
+	for (i32 i = 0; i < 4; i++) {
+		hashtable_set(&table, keys[i], &values[i]);
+	}
 
-	expect_should_be(testval1->b_value, get_testval_1->b_value);
-	expect_should_be(testval1->u_value, get_testval_1->u_value);
+	expect_should_be(4, table.filled);
+
+	for (i32 i = 0; i < 4; i++) {
+		u64* got_ptr;
+		b8 get_result = hashtable_get(&table, keys[i], &got_ptr);
+		expect_to_be_true(get_result);
+
+		expect_should_be(got_ptr, &values[i]);
+		expect_should_be(*got_ptr, values[i]);
+	}
 
 	hashtable_destroy(&table);
 
 	expect_should_be(0, table.memory);
 	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	return true;
 }
 
-u8 hashtable_should_set_and_get_nonexistant(void) {
+u8 hashtable_should_get_nonexistant(void) {
 	hashtable table;
-	u64 element_size = sizeof(u64);
-	u64 element_count = 3;
-	u64 memory[3];
-
-	hashtable_create(element_size, element_count, memory, false, &table);
+	hashtable_create(sizeof(u64), 4, false, &table);
 
 	expect_should_not_be(0, table.memory);
 	expect_should_be(sizeof(u64), table.element_size);
-	expect_should_be(3, table.element_count);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
-	u64 testval1 = 23;
-	hashtable_set(&table, "test1", &testval1);
-	u64 get_testval_1 = 0;
-	hashtable_get(&table, "test2", &get_testval_1);
-	expect_should_be(0, get_testval_1);
+	const char* keys[4] = {
+		"one",
+		"two",
+		"three",
+		"four",
+	};
+	u64 values[4] = {
+		1,
+		2,
+		3,
+		4,
+	};
+
+	for (i32 i = 0; i < 4; i++) {
+		hashtable_set(&table, keys[i], &values[i]);
+	}
+
+	expect_should_be(4, table.filled);
+
+	u64 out;
+	expect_to_be_false(hashtable_get(&table, "five", &out));
 
 	hashtable_destroy(&table);
 
 	expect_should_be(0, table.memory);
 	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	return true;
 }
 
-u8 hashtable_should_set_and_get_ptr_nonexistant(void) {
+u8 hashtable_should_get_nonexistant_ptr(void) {
 	hashtable table;
-	u64 element_size = sizeof(ht_test_struct*);
-	u64 element_count = 3;
-	ht_test_struct* memory[3];
-
-	hashtable_create(element_size, element_count, memory, true, &table);
+	hashtable_create(sizeof(u64*), 4, true, &table);
 
 	expect_should_not_be(0, table.memory);
-	expect_should_be(sizeof(ht_test_struct*), table.element_size);
-	expect_should_be(3, table.element_count);
+	expect_should_be(sizeof(u64*), table.element_size);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_true(table.is_pointer_type);
 
-	ht_test_struct t;
-	ht_test_struct* testval1 = &t;
-	testval1->b_value = true;
-	testval1->u_value = 63;
-	testval1->f_value = 3.1415f;
-	b8 result = hashtable_set_ptr(&table, "test1", (void**)&testval1);
-	expect_to_be_true(result);
+	const char* keys[4] = {
+		"one",
+		"two",
+		"three",
+		"four",
+	};
+	u64 values[4] = {
+		1,
+		2,
+		3,
+		4,
+	};
 
-	ht_test_struct* get_testval_1 = 0;
-	result = hashtable_get_ptr(&table, "test2", (void**)&get_testval_1);
-	expect_to_be_false(result);
-	expect_should_be(0, get_testval_1);
+	for (i32 i = 0; i < 4; i++) {
+		hashtable_set(&table, keys[i], &values[i]);
+	}
+
+	expect_should_be(4, table.filled);
+
+	u64* out;
+	expect_to_be_false(hashtable_get(&table, "five", &out));
 
 	hashtable_destroy(&table);
 
 	expect_should_be(0, table.memory);
 	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	return true;
 }
 
-u8 hashtable_should_set_and_unset_ptr(void) {
+u8 hashtable_should_reset_ptr(void) {
 	hashtable table;
-	u64 element_size = sizeof(ht_test_struct*);
-	u64 element_count = 3;
-	ht_test_struct* memory[3];
-
-	hashtable_create(element_size, element_count, memory, true, &table);
+	hashtable_create(sizeof(u64*), 4, true, &table);
 
 	expect_should_not_be(0, table.memory);
-	expect_should_be(sizeof(ht_test_struct*), table.element_size);
-	expect_should_be(3, table.element_count);
+	expect_should_be(sizeof(u64*), table.element_size);
+	expect_should_be(4, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_true(table.is_pointer_type);
 
-	ht_test_struct t;
-	ht_test_struct* testval1 = &t;
-	testval1->b_value = true;
-	testval1->u_value = 63;
-	testval1->f_value = 3.1415f;
-	// Set it
-	b8 result = hashtable_set_ptr(&table, "test1", (void**)&testval1);
-	expect_to_be_true(result);
+	const char* keys[4] = {
+		"one",
+		"two",
+		"three",
+		"four",
+	};
+	u64 values[4] = {
+		1,
+		2,
+		3,
+		4,
+	};
 
-	// Check that it exists and is correct.
-	ht_test_struct* get_testval_1 = 0;
-	hashtable_get_ptr(&table, "test1", (void**)&get_testval_1);
-	expect_should_be(testval1->b_value, get_testval_1->b_value);
-	expect_should_be(testval1->u_value, get_testval_1->u_value);
+	for (i32 i = 0; i < 4; i++) {
+		hashtable_set(&table, keys[i], &values[i]);
+	}
 
-	// Unset it
-	result = hashtable_set_ptr(&table, "test1", 0);
-	expect_to_be_true(result);
+	expect_to_be_true(hashtable_set(&table, keys[1], 0));
 
-	// Should no longer be found.
-	ht_test_struct* get_testval_2 = 0;
-	result = hashtable_get_ptr(&table, "test1", (void**)&get_testval_2);
-	expect_to_be_false(result);
-	expect_should_be(0, get_testval_2);
+	expect_should_be(4, table.filled);
+
+	u64* out;
+	expect_to_be_true(hashtable_get(&table, "two", &out));
+	expect_should_be(out, 0);
 
 	hashtable_destroy(&table);
 
 	expect_should_be(0, table.memory);
 	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
-
-	return true;
-}
-
-u8 hashtable_try_call_non_ptr_on_ptr_table(void) {
-	hashtable table;
-	u64 element_size = sizeof(ht_test_struct*);
-	u64 element_count = 3;
-	ht_test_struct* memory[3];
-
-	hashtable_create(element_size, element_count, memory, true, &table);
-
-	expect_should_not_be(0, table.memory);
-	expect_should_be(sizeof(ht_test_struct*), table.element_size);
-	expect_should_be(3, table.element_count);
-
-	KDEBUG("The following 2 error messages are intentional.");
-
-	ht_test_struct t;
-	t.b_value = true;
-	t.u_value = 63;
-	t.f_value = 3.1415f;
-	// Try setting the record
-	b8 result = hashtable_set(&table, "test1", &t);
-	expect_to_be_false(result);
-
-	// Try getting the record.
-	ht_test_struct* get_testval_1 = 0;
-	result = hashtable_get(&table, "test1", (void**)&get_testval_1);
-	expect_to_be_false(result);
-
-	hashtable_destroy(&table);
-
-	expect_should_be(0, table.memory);
-	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
-
-	return true;
-}
-
-u8 hashtable_try_call_ptr_on_non_ptr_table(void) {
-	hashtable table;
-	u64 element_size = sizeof(ht_test_struct);
-	u64 element_count = 3;
-	ht_test_struct memory[3];
-
-	hashtable_create(element_size, element_count, memory, false, &table);
-
-	expect_should_not_be(0, table.memory);
-	expect_should_be(sizeof(ht_test_struct), table.element_size);
-	expect_should_be(3, table.element_count);
-
-	KDEBUG("The following 2 error messages are intentional.");
-
-	ht_test_struct t;
-	ht_test_struct* testval1 = &t;
-	testval1->b_value = true;
-	testval1->u_value = 63;
-	testval1->f_value = 3.1415f;
-	// Attempt to call pointer functions.
-	b8 result = hashtable_set_ptr(&table, "test1", (void**)&testval1);
-	expect_to_be_false(result);
-
-	// Try to call pointer function.
-	ht_test_struct* get_testval_1 = 0;
-	result = hashtable_get_ptr(&table, "test1", (void**)&get_testval_1);
-	expect_to_be_false(result);
-
-	hashtable_destroy(&table);
-
-	expect_should_be(0, table.memory);
-	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
-
-	return true;
-}
-
-u8 hashtable_should_set_get_and_update_ptr_successfully(void) {
-	hashtable table;
-	u64 element_size = sizeof(ht_test_struct*);
-	u64 element_count = 3;
-	ht_test_struct* memory[3];
-
-	hashtable_create(element_size, element_count, memory, true, &table);
-
-	expect_should_not_be(0, table.memory);
-	expect_should_be(sizeof(ht_test_struct*), table.element_size);
-	expect_should_be(3, table.element_count);
-
-	ht_test_struct t;
-	ht_test_struct* testval1 = &t;
-	testval1->b_value = true;
-	testval1->u_value = 63;
-	testval1->f_value = 3.1415f;
-	hashtable_set_ptr(&table, "test1", (void**)&testval1);
-
-	ht_test_struct* get_testval_1 = 0;
-	hashtable_get_ptr(&table, "test1", (void**)&get_testval_1);
-	expect_should_be(testval1->b_value, get_testval_1->b_value);
-	expect_should_be(testval1->u_value, get_testval_1->u_value);
-
-	// Update pointed-to values
-	get_testval_1->b_value = false;
-	get_testval_1->u_value = 99;
-	get_testval_1->f_value = 6.69f;
-
-	// Get the pointer again and confirm correct values
-	ht_test_struct* get_testval_2 = 0;
-	hashtable_get_ptr(&table, "test1", (void**)&get_testval_2);
-	expect_to_be_false(get_testval_2->b_value);
-	expect_should_be(99, get_testval_2->u_value);
-	expect_float_to_be(6.69f, get_testval_2->f_value);
-
-	hashtable_destroy(&table);
-
-	expect_should_be(0, table.memory);
-	expect_should_be(0, table.element_size);
-	expect_should_be(0, table.element_count);
+	expect_should_be(0, table.capacity);
+	expect_should_be(0, table.filled);
+	expect_to_be_false(table.is_pointer_type);
 
 	return true;
 }
 
 void hashtable_register_tests(void) {
 	test_manager_register_test(hashtable_should_create_and_destroy, "Hashtable should create and destroy");
-	test_manager_register_test(hashtable_should_set_and_get_successfully, "Hashtable should set and get");
-	test_manager_register_test(hashtable_should_set_and_get_ptr_successfully, "Hashtable should set and get pointer");
-	test_manager_register_test(hashtable_should_set_and_get_nonexistant, "Hashtable should set and get non-existent entry as nothing.");
-	test_manager_register_test(hashtable_should_set_and_get_ptr_nonexistant, "Hashtable should set and get non-existent pointer entry as nothing.");
-	test_manager_register_test(hashtable_should_set_and_unset_ptr, "Hashtable should set and unset pointer entry as nothing.");
-	test_manager_register_test(hashtable_try_call_non_ptr_on_ptr_table, "Hashtable try calling non-pointer functions on pointer type table.");
-	test_manager_register_test(hashtable_try_call_ptr_on_non_ptr_table, "Hashtable try calling pointer functions on non-pointer type table.");
-	test_manager_register_test(hashtable_should_set_get_and_update_ptr_successfully, "Hashtable Should get pointer, update, and get again successfully.");
+	test_manager_register_test(hashtable_should_set_and_get_successfully, "Hashtable should get and set successfully");
+	test_manager_register_test(hashtable_should_grow_successfully, "Hashtable should grow successfully");
+	test_manager_register_test(hashtable_should_set_and_get_ptr_successfully, "Hashtable should get and set pointer successfully");
+	test_manager_register_test(hashtable_should_get_nonexistant, "Hashtable should get nonexistant and fail");
+	test_manager_register_test(hashtable_should_get_nonexistant_ptr, "Hashtable should get nonexistant pointer and fail");
+	test_manager_register_test(hashtable_should_reset_ptr, "Hashtable should reset pointer");
 }

--- a/kohi.core/src/containers/hashtable.c
+++ b/kohi.core/src/containers/hashtable.c
@@ -1,77 +1,137 @@
 #include "hashtable.h"
 
+#include "defines.h"
 #include "logger.h"
 #include "memory/kmemory.h"
+#include "strings/kstring.h"
 
-static u64 hash_name(const char* name, u32 element_count) {
-	// A multipler to use when generating a hash. Prime to hopefully avoid collisions.
-	static const u64 multiplier = 97;
+#define MAX_OCCUPANCY 0.75f
+#define GROW_FACTOR 2
 
-	unsigned const char* us;
-	u64 hash = 0;
+typedef u8 ht_control;
 
-	for (us = (unsigned const char*)name; *us; us++) {
-		hash = hash * multiplier + *us;
+typedef u64 ht_h1; // First part of the hash, offset into the start position.
+typedef u8 ht_h2;  // Second part of the hash, check-sum for faster iteration.
+
+// h1 is stored in last 7 bytes of the 8-byte hash,
+// h2 is stored in the first byte.
+#define GET_H1(_hash) (((_hash) & ~0xFFULL) >> 8)
+#define GET_H2(_hash) ((_hash) & 0xFF)
+
+// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+#define FNV_PRIME 0x00000100000001b3
+#define FNV_OFFSET_BASIS 0xcbf29ce484222325
+static u64 fnv_1a(const char* str) {
+	u64 hash = FNV_OFFSET_BASIS;
+	for (; *str; str++) {
+		hash ^= *str;
+		hash *= FNV_PRIME;
 	}
-
-	// Mod it against the size of the table.
-	hash %= element_count;
-
 	return hash;
 }
 
-void hashtable_create(u64 element_size, u32 element_count, void* memory, b8 is_pointer_type, hashtable* out_hashtable) {
-	if (!memory || !out_hashtable) {
-		KERROR("hashtable_create failed! Pointer to memory and out_hashtable are required.");
+static void grow_and_rehash(hashtable* table);
+
+static ht_control* get_control_block(hashtable* table);
+static kstring* get_key_block(hashtable* table);
+static void* get_data_block(hashtable* table);
+
+void hashtable_create(u64 element_size, u64 initial_capacity, b8 is_pointer_type, hashtable* out_hashtable) {
+	if (!out_hashtable) {
+		KERROR("hashtable_create failed! Pointer to out_hashtable is required.");
 		return;
 	}
-	if (!element_count || !element_size) {
-		KERROR("element_size and element_count must be a positive non-zero value.");
+	if (!initial_capacity || !element_size) {
+		KERROR("element_size and initial_capacity must be a positive non-zero value.");
 		return;
 	}
 
-	// TODO: Might want to require an allocator and allocate this memory instead.
-	out_hashtable->memory = memory;
-	out_hashtable->element_count = element_count;
+	out_hashtable->capacity = initial_capacity;
 	out_hashtable->element_size = element_size;
+	out_hashtable->filled = 0;
 	out_hashtable->is_pointer_type = is_pointer_type;
-	kzero_memory(out_hashtable->memory, element_size * element_count);
+
+	u64 allocation_size = (sizeof(ht_control) + sizeof(kstring) + element_size) * initial_capacity;
+	out_hashtable->memory = kallocate(allocation_size, MEMORY_TAG_HASHTABLE);
+	kzero_memory(out_hashtable->memory, allocation_size);
 }
 
 void hashtable_destroy(hashtable* table) {
-	if (table) {
-		// TODO: If using allocator above, free memory here.
-		kzero_memory(table, sizeof(hashtable));
+	if (!table) {
+		KERROR("hashtable_destroy failed! Pointer to table is required.");
+		return;
 	}
+
+	u64 allocation_size = (sizeof(ht_control) + sizeof(kstring) + table->element_size) * table->capacity;
+
+	if (table->filled > 0) {
+		ht_control* control_block = get_control_block(table);
+		kstring* key_block = get_key_block(table);
+		for (u64 i = 0; i < table->capacity; i++) {
+			if (control_block[i] != 0) {
+				kstring_destroy(&key_block[i]);
+			}
+		}
+	}
+
+	kfree(table->memory, allocation_size, MEMORY_TAG_HASHTABLE);
+	kzero_memory(table, sizeof(hashtable));
 }
 
-b8 hashtable_set(hashtable* table, const char* name, void* value) {
-	if (!table || !name || !value) {
-		KERROR("hashtable_set requires table, name and value to exist.");
-		return false;
-	}
-	if (table->is_pointer_type) {
-		KERROR("hashtable_set should not be used with tables that have pointer types. Use hashtable_set_ptr instead.");
-		return false;
-	}
-
-	u64 hash = hash_name(name, table->element_count);
-	kcopy_memory(table->memory + (table->element_size * hash), value, table->element_size);
-	return true;
-}
-
-b8 hashtable_set_ptr(hashtable* table, const char* name, void** value) {
+b8 hashtable_set(hashtable* table, const char* name, const void* value) {
 	if (!table || !name) {
-		KWARN("hashtable_set_ptr requires table and name  to exist.");
-		return false;
-	}
-	if (!table->is_pointer_type) {
-		KERROR("hashtable_set_ptr should not be used with tables that do not have pointer types. Use hashtable_set instead.");
+		KERROR("hashtable_set requires table and name to exist.");
 		return false;
 	}
 
-	u64 hash = hash_name(name, table->element_count);
-	((void**)table->memory)[hash] = value ? *value : 0;
+	if (!value && !table->is_pointer_type) {
+		KERROR("hashtable_set requires valid pointer to value when called on non-pointer type hashtable.");
+		return false;
+	}
+
+	u64 hash = fnv_1a(name);
+	ht_h1 h1 = GET_H1(hash);
+	ht_h2 h2 = GET_H2(hash);
+
+	u64 pos = h1 % table->capacity;
+
+	ht_control* control_block = get_control_block(table);
+	kstring* key_block = get_key_block(table);
+	void* data_block = get_data_block(table);
+
+	while (1) {
+		if (control_block[pos] == 0) {
+			// cells is empty, set H2 check-sum, key and value.
+			control_block[pos] = h2;
+			kstring_from_cstring(name, &key_block[pos]);
+			void* slot = data_block + (table->element_size * pos);
+			if (table->is_pointer_type)
+				*(void**)slot = (void*)value;
+			else
+				kcopy_memory(slot, value, table->element_size);
+
+			table->filled += 1;
+
+			if ((f32)table->filled / (f32)table->capacity >= MAX_OCCUPANCY) {
+				grow_and_rehash(table);
+			}
+
+			break;
+		} else if (control_block[pos] == h2 && strings_equal(name, key_block[pos].data)) {
+			// cell with identical H2 check-sum and key, replace its content.
+			void* slot = data_block + (table->element_size * pos);
+			if (table->is_pointer_type)
+				*(void**)slot = (void*)value;
+			else
+				kcopy_memory(slot, value, table->element_size);
+
+			break;
+		}
+
+		// Cycle until we find a suitable cell.
+		pos = (pos + 1) % table->capacity;
+	}
+
 	return true;
 }
 
@@ -80,43 +140,114 @@ b8 hashtable_get(hashtable* table, const char* name, void* out_value) {
 		KWARN("hashtable_get requires table, name and out_value to exist.");
 		return false;
 	}
-	if (table->is_pointer_type) {
-		KERROR("hashtable_get should not be used with tables that have pointer types. Use hashtable_set_ptr instead.");
-		return false;
+
+	u64 hash = fnv_1a(name);
+	ht_h1 h1 = GET_H1(hash);
+	ht_h2 h2 = GET_H2(hash);
+
+	u64 pos = h1 % table->capacity;
+
+	ht_control* control_block = get_control_block(table);
+	kstring* key_block = get_key_block(table);
+	void* data_block = get_data_block(table);
+
+	while (1) {
+		if (control_block[pos] == 0) // Cell is empty, break from the loop.
+			break;
+		else if (control_block[pos] == h2 && strings_equal(name, key_block[pos].data)) {
+			// Cell found, set the out_value and return true.
+			void* slot = data_block + (table->element_size * pos);
+			if (table->is_pointer_type)
+				*(void**)out_value = *(void**)slot;
+			else
+				kcopy_memory(out_value, slot, table->element_size);
+
+			return true;
+		}
+
+		// Cycle until we find a required cell (or empty).
+		pos = (pos + 1) % table->capacity;
 	}
-	u64 hash = hash_name(name, table->element_count);
-	kcopy_memory(out_value, table->memory + (table->element_size * hash), table->element_size);
-	return true;
+
+	// Value is not presented in the hashtable.
+	return false;
 }
 
-b8 hashtable_get_ptr(hashtable* table, const char* name, void** out_value) {
-	if (!table || !name || !out_value) {
-		KWARN("hashtable_get_ptr requires table, name and out_value to exist.");
-		return false;
-	}
-	if (!table->is_pointer_type) {
-		KERROR("hashtable_get_ptr should not be used with tables that do not have pointer types. Use hashtable_get instead.");
-		return false;
+void hashtable_foreach(hashtable* table, hashtable_foreach_fn foreach_fn, void* user_data) {
+	if (!table || !foreach_fn) {
+		KWARN("hashtable_foreach requires table and a foreach_fn");
+		return;
 	}
 
-	u64 hash = hash_name(name, table->element_count);
-	*out_value = ((void**)table->memory)[hash];
-	return *out_value != 0;
+	ht_control* control_block = get_control_block(table);
+	kstring* key_block = get_key_block(table);
+	void* data_block = get_data_block(table);
+
+	for (u64 i = 0; i < table->capacity; i++) {
+		if (control_block[i] != 0) {
+			foreach_fn(i, &key_block[i], data_block + (table->element_size * i), user_data);
+		}
+	}
 }
 
-b8 hashtable_fill(hashtable* table, void* value) {
-	if (!table || !value) {
-		KWARN("hashtable_fill requires table and value to exist.");
-		return false;
-	}
-	if (table->is_pointer_type) {
-		KERROR("hashtable_fill should not be used with tables that have pointer types.");
-		return false;
+static void grow_and_rehash(hashtable* table) {
+	u64 old_capacity = table->capacity;
+	u64 old_allocation_size = (sizeof(ht_control) + sizeof(kstring) + table->element_size) * old_capacity;
+	void* old_memory = table->memory;
+	ht_control* old_control_block = get_control_block(table);
+	kstring* old_key_block = get_key_block(table);
+	void* old_data_block = get_data_block(table);
+
+	u64 new_capacity = old_capacity * GROW_FACTOR;
+	u64 new_allocation_size = (sizeof(ht_control) + sizeof(kstring) + table->element_size) * new_capacity;
+	table->capacity = new_capacity;
+	table->memory = kallocate(new_allocation_size, MEMORY_TAG_HASHTABLE);
+	ht_control* new_control_block = get_control_block(table);
+	kstring* new_key_block = get_key_block(table);
+	void* new_data_block = get_data_block(table);
+
+	for (u64 i = 0; i < old_capacity; i++) {
+		if (old_control_block[i] == 0)
+			continue;
+
+		kstring* key = &old_key_block[i];
+		u64 hash = fnv_1a(key->data);
+		ht_h1 h1 = GET_H1(hash);
+		ht_h2 h2 = GET_H2(hash);
+
+		u64 pos = h1 % table->capacity;
+
+		while (1) {
+			// We assume that FNV-1a is good enough to avoid H2 collisions, so only check for empty cells.
+			if (new_control_block[pos] == 0) {
+				new_control_block[pos] = h2;
+				kcopy_memory(&new_key_block[pos], key, sizeof(kstring));
+
+				void* slot_dst = new_data_block + (table->element_size * pos);
+				void* slot_src = old_data_block + (table->element_size * i);
+				if (table->is_pointer_type)
+					*(void**)slot_dst = *(void**)slot_src;
+				else
+					kcopy_memory(slot_dst, slot_src, table->element_size);
+
+				break;
+			}
+
+			pos = (pos + 1) % table->capacity;
+		}
 	}
 
-	for (u32 i = 0; i < table->element_count; ++i) {
-		kcopy_memory(table->memory + (table->element_size * i), value, table->element_size);
-	}
+	kfree(old_memory, old_allocation_size, MEMORY_TAG_HASHTABLE);
+}
 
-	return true;
+static ht_control* get_control_block(hashtable* table) {
+	return table->memory + 0;
+}
+
+static kstring* get_key_block(hashtable* table) {
+	return table->memory + sizeof(ht_control) * table->capacity;
+}
+
+static void* get_data_block(hashtable* table) {
+	return table->memory + (sizeof(ht_control) + sizeof(kstring)) * table->capacity;
 }

--- a/kohi.core/src/containers/hashtable.h
+++ b/kohi.core/src/containers/hashtable.h
@@ -12,33 +12,29 @@
 #pragma once
 
 #include "defines.h"
+#include "strings/kstring.h"
 
 /**
  * @brief Represents a simple hashtable. Members of this structure
  * should not be modified outside the functions associated with it.
- *
- * For non-pointer types, table retains a copy of the value.For
- * pointer types, make sure to use the _ptr setter and getter. Table
- * does not take ownership of pointers or associated memory allocations,
- * and should be managed externally.
  */
 typedef struct hashtable {
+	u64 capacity;
 	u64 element_size;
-	u32 element_count;
-	b8 is_pointer_type;
+	u64 filled;
 	void* memory;
+	b8 is_pointer_type;
 } hashtable;
 
 /**
  * @brief Creates a hashtable and stores it in out_hashtable.
  *
  * @param element_size The size of each element in bytes.
- * @param element_count The maximum number of elements. Cannot be resized.
- * @param memory A pointer to hold a block of memory to be used. Internally allocated. Will be equal in size to element_size * element_count.
+ * @param initial_capacity Initial capacity of the hashtable.
  * @param is_pointer_type Indicates if this hashtable will hold pointer types.
  * @param out_hashtable A pointer to a hashtable in which to hold relevant data.
  */
-KAPI void hashtable_create(u64 element_size, u32 element_count, void* memory, b8 is_pointer_type, hashtable* out_hashtable);
+KAPI void hashtable_create(u64 element_size, u64 initial_capacity, b8 is_pointer_type, hashtable* out_hashtable);
 
 /**
  * @brief Destroys the provided hashtable. Does not release memory for pointer types.
@@ -56,18 +52,7 @@ KAPI void hashtable_destroy(hashtable* table);
  * @param value The value to be set. Required.
  * @return True, or false if a null pointer is passed.
  */
-KAPI b8 hashtable_set(hashtable* table, const char* name, void* value);
-
-/**
- * @brief Stores a pointer as provided in value in the hashtable.
- * Only use for tables which were created with is_pointer_type = true.
- *
- * @param table A pointer to the table to get from. Required.
- * @param name The name of the entry to set. Required.
- * @param value A pointer value to be set. Can pass 0 to 'unset' an entry.
- * @return True; or false if a null pointer is passed or if the entry is 0.
- */
-KAPI b8 hashtable_set_ptr(hashtable* table, const char* name, void** value);
+KAPI b8 hashtable_set(hashtable* table, const char* name, const void* value);
 
 /**
  * @brief Obtains a copy of data present in the hashtable.
@@ -81,23 +66,16 @@ KAPI b8 hashtable_set_ptr(hashtable* table, const char* name, void** value);
 KAPI b8 hashtable_get(hashtable* table, const char* name, void* out_value);
 
 /**
- * @brief Obtains a pointer to data present in the hashtable.
- * Only use for tables which were created with is_pointer_type = true.
- *
- * @param table A pointer to the table to retrieved from. Required.
- * @param name The name of the entry to retrieved. Required.
- * @param value A pointer to store the retrieved value. Required.
- * @return True if retrieved successfully; false if a null pointer is passed or is the retrieved value is 0.
+ * @brief Pointer to a function that will be called on every object stored inside hashtable
+ * when passed to the `hashtable_foreach`.
  */
-KAPI b8 hashtable_get_ptr(hashtable* table, const char* name, void** out_value);
+typedef void (*hashtable_foreach_fn)(u64 index, const kstring* key, void* data, void* user_data);
 
 /**
- * @brief Fills all entries in the hashtable with the given value.
- * Useful when non-existent names should return some default value.
- * Should not be used with pointer table types.
+ * @brief Calls a foreach_fn on every object stored inside hashtable.
  *
- * @param table A pointer to the table filled. Required.
- * @param value The value to be filled with. Required.
- * @return True if successful; otherwise false.
+ * @param table A pointer to the table to iterate on. Required.
+ * @param foreach_fn Foreach function that will be called on every object. Required.
+ * @param user_data User data that is passed to the foreach_fn.
  */
-KAPI b8 hashtable_fill(hashtable* table, void* value);
+KAPI void hashtable_foreach(hashtable* table, hashtable_foreach_fn foreach_fn, void* user_data);


### PR DESCRIPTION
## API changes
There's some breaking API changes:
* Added `filled` field to the `hashtable` struct
* Renamed field `element_count` to `capacity` and changed its type from `u32` to `u64`
* Removed argument `void *memory` from `hashtable_create`'s function signature
* Removed functions `hashtable_set_ptr` and `hashtable_get_ptr`, their behavior is implemented inside `hashtable_set` and `hashtable_get`
* Removed function `hashtable_fill` because all cells in hashtable are zero-initialized by default, and filling it without marking cells as occupied doesn't make any sense now, because of accessing mechanism, and marking them as occupied will just grow hashtable infinitely, because hashtable grows when `filled` to `capacity` ratio is _greater or equal_ to `MAX_OCCUPANCY` (defined in `kohi.core/src/containers/hashtable.c`)
* Added function `hashtable_foreach` to iterate over the hashtable

## How does it work
### Hash
I replaced previous hash function with 64-bit version of [FNV-1a](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function).

Hash separates into 2 parts, let's call them H1 and H2.  
H1 is higher 56 bits of the hash
H2 is lower 8 bits of the hash

H1 will be used for initial indexing into the hashtable, H2 - for check-sums.

### Hashtable data
Now `memory` field is used for 3 things:
1. Control block (H2s)
2. Key block (copies of keys wrapped into `kstring`s)
3. Data block (stored values)

### `hashtable_set()`
We get hash from key, get H1 and H2 of the hash, take a module of H1, this will be the initial position in the hashtable.

We step into it, and then seek for valid cell (either empty or a cell with matching H2 (control) and key).

For empty cell we create `kstring` key for it, copy the value, set its control to H2 and increment `filled` field by one. If `filled` to `capacity` ratio is _greater or equal_ to `MAX_OCCUPANCY`, `grow_and_rehash` will be called. For matching cell, we just replace the value.

### `hashtable_get()`
Get hash, H1, H2, initial pos, bla bla

Seek for cell with matching H2 and key. If found, set `out_value` to cell's content.
If we step into an empty cell, it means that we haven't found matching cell, return false.

The code is kinda straightforward, I just wanted to make these H1, H2, control things clear, because the may confuse you if you don't very familiar with the thing.

Resolves #248

I think this pr message took me longer to write than the pr itself, lol :P

Thanks
